### PR TITLE
Fix scrolling visibility on discussions

### DIFF
--- a/src/components/side.css
+++ b/src/components/side.css
@@ -257,9 +257,43 @@
 }
 
 .discussionsList {
-  height: 30vh;
+  max-height: 30vh;
   gap: 2rem;
   overflow-y: scroll;
+  --scrollbar-width: 0.5rem;
+  --mask-height: 2rem;
+  padding-bottom: var(--mask-height);
+  padding-top: var(--mask-height);
+  padding-right: 1.25rem;
+  --mask-image-content: linear-gradient(
+    to bottom,
+    transparent,
+    black var(--mask-height),
+    black calc(100% - var(--mask-height)),
+    transparent
+  );
+  --mask-size-content: calc(100% - var(--scrollbar-width)) 100%;
+  --mask-image-scrollbar: linear-gradient(black, black);
+  --mask-size-scrollbar: var(--scrollbar-width) 100%;
+  mask-image: var(--mask-image-content), var(--mask-image-scrollbar);
+  mask-size: var(--mask-size-content), var(--mask-size-scrollbar);
+  mask-position: 0 0, 100% 0;
+  mask-repeat: no-repeat, no-repeat;
+  scrollbar-width: thin;
+  scrollbar-color: currentColor transparent;
+}
+
+.discussionsList::-webkit-scrollbar {
+  width: var(--scrollbar-width);
+}
+
+.discussionsList::-webkit-scrollbar-thumb {
+  background-color: currentColor;
+  border-radius: 9999rem;
+}
+
+.discussionsList::-webkit-scrollbar-track {
+  background-color: transparent;
 }
 
 .side-filter {


### PR DESCRIPTION
Fix scrolling visibility on discussions list (Chat list should have a blur field in the end to indicate that more items are existing afterwards if the chat list is overflowing)